### PR TITLE
Platform jruby for jdbc gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,10 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in active_record_upsert.gemspec
 gemspec
 
-gem 'activerecord-jdbc-adapter', github: 'jensnockert/activerecord-jdbc-adapter', branch: 'activerecord-50'
+gem 'activerecord-jdbc-adapter',
+    github: 'jensnockert/activerecord-jdbc-adapter',
+    branch: 'activerecord-50',
+    platform: :jruby
 
 gem 'activerecord-jdbcpostgresql-adapter',
     github: 'jensnockert/activerecord-jdbc-adapter',


### PR DESCRIPTION
Without this change, ruby-2.3.0 fails immediately.