### PR TITLE
Update database_cleaner to 1.5.3

### DIFF
--- a/active_record_upsert.gemspec
+++ b/active_record_upsert.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "> 0"
-  spec.add_development_dependency "database_cleaner", "~> 1.5.1"
+  spec.add_development_dependency "database_cleaner", "~> 1.5.3"
   spec.add_development_dependency "rails", "~> 5.0.0.beta3"
 end


### PR DESCRIPTION
```
NEW FEATURES/CHANGES

* Use default_client with mongoid 5.0 (@stjhimy)
* Added comparable support for strategies (@st0012)
* Better README instructions that suggest `append_after` (@jrochkind)
* Removed deprecation warnings for Rails 5.0+ (@pschambacher)
* Upgrade to RSpec 2.14 (@skalee)
BUG FIXES

* @dmitrypol fixed issue #409
* @schmierkov fixed the Travis builds with PR #416
* @shosti fixed issue #345
* @kylev fixed issue #379
* @skalee fixed the Travis builds for Neo4j with PR #433

```

1.5.2 had this:
https://gemnasium.com/gems/database_cleaner/versions/1.5.2