### PR TITLE
Travis: use pg9.5 pre-installed on the Trusty infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 language: ruby
 env:
   - DATABASE_URL="postgresql://postgres@localhost/upsert_test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,15 @@
 sudo: required
 language: ruby
 env:
-  - DATABASE_URL="postgresql://travis@localhost/upsert_test"
+  - DATABASE_URL="postgresql://postgres@localhost/upsert_test"
 rvm:
-  - 2.3.0
+  - 2.3.1
 before_script:
-  - sudo /etc/init.d/postgresql stop
-  - sudo apt-get -y remove --purge postgresql-9.1 postgresql-9.2 postgresql-9.3 postgresql-9.4
-  - sudo apt-get -y autoremove
-  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7FCC7D46ACCC4CF8
-  - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
-  - sudo apt-get update
-  - sudo apt-get -y install postgresql-9.5
-  - sudo sh -c 'echo "host all all 127.0.0.1/32 trust" > /etc/postgresql/9.5/main/pg_hba.conf'
-  - sudo sh -c 'echo "hostnossl all all 127.0.0.1/32 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
-  - sudo sh -c 'echo "hostnossl all all 0.0.0.0/0 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
-  - sudo sh -c 'echo "hostnossl all travis 127.0.0.1/32 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
-  - sudo sh -c 'echo "hostnossl all travis 0.0.0.0/0 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
-  - sudo sh -c 'echo "local all postgres trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
-  - sudo sh -c 'echo "local all travis trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
-  - sudo /etc/init.d/postgresql restart
-  - psql --version
-  - createuser --echo -U postgres --createdb travis
-  - createdb --echo -U postgres --owner "travis" upsert_test
+  - createdb --echo -U postgres upsert_test
   - psql -U postgres upsert_test < spec/dummy/db/structure.sql
 
-before_install: gem install bundler -v 1.11.2
+before_install: gem install bundler -v 1.13.3
+
+addons:
+  postgresql: "9.5"
+


### PR DESCRIPTION
[Travis docs](https://docs.travis-ci.com/user/database-setup/) point to there being a PG 9.5 on their ["trusty" servers](https://docs.travis-ci.com/user/trusty-ci-environment/), which require `sudo`.

This PR changes the installation-heavy build script to use those instead of building a new version.

And, it updates testing to MRI 2.3.1.