### PR TITLE
Bugfix: Re-introduce the require psql adapter line

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ r.upsert
 => #<MyRecord id: 2, name: "bar", created_at: "2016-02-20 14:17:50", updated_at: "2016-02-20 14:18:49", wisdom: 3>
 ```
 
+## Tests
+
+Make sure to have an upsert_test database:
+
+```shell
+DATABASE_URL=postgresql://localhost/upsert_test RAILS_ENV=test bundle exec bin/rails db:environment:set RAILS_ENV=test
+DATABASE_URL=postgresql://localhost/upsert_test RAILS_ENV=test bundle exec rake db:create db:migrate
+```
+
+Then run `rspec`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jesjos/active_record_upsert.

--- a/lib/active_record_upsert/active_record.rb
+++ b/lib/active_record_upsert/active_record.rb
@@ -1,3 +1,6 @@
+unless defined?(::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+  require 'active_record/connection_adapters/postgresql_adapter'
+end
 Dir.glob(File.join(__dir__, 'active_record/**/*.rb')) do |f|
   require f
 end

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.1
--- Dumped by pg_dump version 9.5.2
+-- Dumped from database version 9.5.4
+-- Dumped by pg_dump version 9.5.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;


### PR DESCRIPTION
This PR re-adds a line which was removed - by me, by mistake - in an earlier commit.

- add the missing require
- add a Tests section to README
- re-generate a file