### PR TITLE
Gemspec: Rails 5 has been released, fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ r.upsert
 Make sure to have an upsert_test database:
 
 ```shell
-DATABASE_URL=postgresql://localhost/upsert_test RAILS_ENV=test bundle exec bin/rails db:environment:set RAILS_ENV=test
-DATABASE_URL=postgresql://localhost/upsert_test RAILS_ENV=test bundle exec rake db:create db:migrate
+bin/run_rails.sh db:create db:migrate DATABASE_URL=postgresql://localhost/upsert_test
 ```
 
 Then run `rspec`.

--- a/active_record_upsert.gemspec
+++ b/active_record_upsert.gemspec
@@ -17,16 +17,16 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activerecord', '~> 5.0.0.beta4'
+  spec.add_runtime_dependency 'activerecord', '>= 5.0', '< 5.1'
   spec.add_runtime_dependency "arel", "~>7.0"
 
   spec.platform = Gem::Platform::RUBY
   spec.add_runtime_dependency 'pg', '~> 0.18'
 
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler", ">= 1.13"
+  spec.add_development_dependency "rake", ">= 10.0"
+  spec.add_development_dependency "rspec", ">= 3.0", "< 4"
   spec.add_development_dependency "pry", "> 0"
   spec.add_development_dependency "database_cleaner", "~> 1.5.3"
-  spec.add_development_dependency 'rails', '~> 5.0.0.beta4'
+  spec.add_development_dependency 'rails', '>= 5.0', '< 5.1'
 end


### PR DESCRIPTION
This PR changes the gemspec's dependencies to rely on Rails 5.0.

It also fixes the README's testing section to use the bin/ scripts distributed with the app.