### PR TITLE
Custom keys by paul hoffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Also, it's possible to specify which columns should be used for the conflict cla
 
 ```
 class Vehicle < ActiveRecord::Base
-  upsert_by [:make, :name]
+  upsert_keys [:make, :name]
 end
 
 Vehicle.upsert(make: 'Ford', name: 'F-150', doors: 4)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ r.upsert
 => #<MyRecord id: 2, name: "bar", created_at: "2016-02-20 14:17:50", updated_at: "2016-02-20 14:18:49", wisdom: 3>
 ```
 
+Also, it's possible to specify which columns should be used for the conflict clause. **These must comprise a unique index in Postgres.**
+
+```
+class Vehicle < ActiveRecord::Base
+  upsert_by [:make, :name]
+end
+
+Vehicle.upsert(make: 'Ford', name: 'F-150', doors: 4)
+=> #<Vehicle id: 1, make: 'Ford', name: 'Focus', doors: 2>
+
+Vehicle.create(make: 'Ford', name: 'Focus', doors: 4)
+=> #<Vehicle id: 2, make: 'Ford', name: 'Focus', doors: 4>
+
+r = Vehicle.new(make: 'Ford', name: 'F-150')
+r.doors = 2
+r.upsert
+=> #<Vehicle id: 1, make: 'Ford', name: 'Focus', doors: 2>
+```
+
 ## Tests
 
 Make sure to have an upsert_test database:

--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/jesjos
 - Jens Nockert
 - Olle Jonsson
 - Simon Dahlbacka
+- Paul Hoffer

--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -31,6 +31,13 @@ module ActiveRecordUpsert
             new(attributes, &block).upsert
           end
         end
+        def upsert_by(*keys)
+          keys = keys.first if keys.size == 1 # support single string/symbol, multiple string/symbols, and array
+          @_upsert_keys = Array(keys).map(&:to_s)
+        end
+        def _upsert_keys
+          @_upsert_keys
+        end
       end
     end
   end

--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -31,12 +31,10 @@ module ActiveRecordUpsert
             new(attributes, &block).upsert
           end
         end
-        def upsert_by(*keys)
+        def upsert_keys(*keys)
+          return @_upsert_keys if keys.empty?
           keys = keys.first if keys.size == 1 # support single string/symbol, multiple string/symbols, and array
           @_upsert_keys = Array(keys).map(&:to_s)
-        end
-        def _upsert_keys
-          @_upsert_keys
         end
       end
     end

--- a/lib/active_record_upsert/active_record/relation.rb
+++ b/lib/active_record_upsert/active_record/relation.rb
@@ -14,7 +14,7 @@ module ActiveRecordUpsert
         im.into arel_table
 
         substitutes, binds = substitute_values values
-        column_arr = self.klass._upsert_keys || [primary_key]
+        column_arr = self.klass.upsert_keys || [primary_key]
         column_name = column_arr.join(',')
 
         cm = arel_table.create_on_conflict_do_update

--- a/lib/active_record_upsert/active_record/relation.rb
+++ b/lib/active_record_upsert/active_record/relation.rb
@@ -14,11 +14,13 @@ module ActiveRecordUpsert
         im.into arel_table
 
         substitutes, binds = substitute_values values
+        column_arr = self.klass._upsert_keys || [primary_key]
+        column_name = column_arr.join(',')
 
         cm = arel_table.create_on_conflict_do_update
-        cm.target = arel_table[primary_key]
+        cm.target = arel_table[column_name]
+        filter = ->(o) { [*column_arr, 'created_at'].include?(o.name) }
 
-        filter = ->(o) { [primary_key, 'created_at'].include?(o.name) }
         cm.set(substitutes.reject { |s| filter.call(s.first) })
         on_conflict_binds = binds.reject(&filter)
 
@@ -29,8 +31,8 @@ module ActiveRecordUpsert
         @klass.connection.upsert(
           im,
           'SQL',
-          primary_key,
-          primary_key_value,
+          primary_key,       # not used
+          primary_key_value, # not used
           nil,
           binds + on_conflict_binds)
       end

--- a/lib/active_record_upsert/arel/visitors/to_sql.rb
+++ b/lib/active_record_upsert/arel/visitors/to_sql.rb
@@ -13,7 +13,7 @@ module ActiveRecordUpsert
 
         def visit_Arel_Nodes_OnConflict o, collector
           collector << "ON CONFLICT "
-          collector << " (#{quote_column_name o.target.name}) "
+          collector << " (#{quote_column_name o.target.name}) ".gsub(',', '","')
           maybe_visit o.action, collector
         end
 

--- a/spec/active_record/key_spec.rb
+++ b/spec/active_record/key_spec.rb
@@ -1,0 +1,56 @@
+module ActiveRecord
+  describe 'Alernate conflict keys' do
+    describe '#upsert' do
+      let(:record) { Vehicle.new(make: 'Ford', name: 'Focus') }
+      it 'calls save/create/commit callbacks' do
+        expect(record).to receive(:before_s)
+        expect(record).to receive(:after_s)
+        expect(record).to receive(:after_c)
+        expect(record).to receive(:before_c)
+        expect(record).to receive(:after_com)
+        record.upsert
+      end
+
+      context 'when the record does not exist' do
+        it 'sets timestamps' do
+          record.upsert
+          expect(record.created_at).not_to be_nil
+          expect(record.updated_at).not_to be_nil
+        end
+      end
+
+      context 'when the record already exists' do
+        let(:attrs) { {make: 'Ford', name: 'Focus'} }
+        before { Vehicle.create(attrs) }
+        it 'sets the updated_at timestamp' do
+          first_updated_at = Vehicle.find_by(attrs).updated_at
+          upserted = Vehicle.new(attrs)
+          upserted.upsert
+          expect(upserted.updated_at).to be > first_updated_at
+        end
+
+        it 'does not reset the created_at timestamp' do
+          first_created_at = Vehicle.find_by(attrs).created_at
+          upserted = Vehicle.new(attrs)
+          upserted.upsert
+          expect(upserted.created_at).to eq(first_created_at)
+        end
+
+        it 'loads the data from the db' do
+          upserted = Vehicle.new(**attrs, wheels_count: 1)
+          upserted.upsert
+          expect(upserted.wheels_count).to eq(1)
+        end
+      end
+
+      context 'when the record is not new' do
+        let(:attrs) { {make: 'Ford', name: 'Focus'} }
+        it 'raises an error' do
+          record = Vehicle.create(attrs)
+          record.save
+          expect { record.upsert }.to raise_error(RecordSavedError)
+        end
+      end
+    end
+  end
+end

--- a/spec/active_record/key_spec.rb
+++ b/spec/active_record/key_spec.rb
@@ -42,6 +42,50 @@ module ActiveRecord
           expect(upserted.wheels_count).to eq(1)
         end
       end
+      context 'different ways of setting keys' do
+        let(:attrs) { {make: 'Ford', name: 'Focus'} }
+        before { Vehicle.create(attrs) }
+        it 'works with multiple symbol args' do
+          Vehicle.upsert_keys :make, :name
+          upserted = Vehicle.new(**attrs, wheels_count: 1)
+          upserted.upsert
+          expect(upserted.wheels_count).to eq(1)
+        end
+        it 'works with multiple string args' do
+          Vehicle.upsert_keys 'make', 'name'
+          upserted = Vehicle.new(**attrs, wheels_count: 1)
+          upserted.upsert
+          expect(upserted.wheels_count).to eq(1)
+        end
+        it 'works with array of symbols' do
+          Vehicle.upsert_keys [:make, :name]
+          upserted = Vehicle.new(**attrs, wheels_count: 1)
+          upserted.upsert
+          expect(upserted.wheels_count).to eq(1)
+        end
+        it 'works with array of strings' do
+          Vehicle.upsert_keys ['make', 'name']
+          upserted = Vehicle.new(**attrs, wheels_count: 1)
+          upserted.upsert
+          expect(upserted.wheels_count).to eq(1)
+        end
+        it 'works with a single symbol' do
+          v = Vehicle.create
+          Vehicle.upsert_keys :id
+          upserted = Vehicle.new(id: v.id, wheels_count: 1)
+          upserted.upsert
+          expect(upserted.wheels_count).to eq(1)
+          expect(upserted.id).to eq(v.id)
+        end
+        it 'works with a single string' do
+          v = Vehicle.create
+          Vehicle.upsert_keys 'id'
+          upserted = Vehicle.new(id: v.id, wheels_count: 1)
+          upserted.upsert
+          expect(upserted.wheels_count).to eq(1)
+          expect(upserted.id).to eq(v.id)
+        end
+      end
 
       context 'when the record is not new' do
         let(:attrs) { {make: 'Ford', name: 'Focus'} }

--- a/spec/dummy/app/models/vehicle.rb
+++ b/spec/dummy/app/models/vehicle.rb
@@ -1,2 +1,24 @@
 class Vehicle < ApplicationRecord
+  upsert_by :make, :name
+
+  before_save :before_s
+  after_save :after_s
+  before_create :before_c
+  after_create :after_c
+  after_commit :after_com
+
+  def before_s
+  end
+
+  def after_s
+  end
+
+  def before_c
+  end
+
+  def after_c
+  end
+
+  def after_com
+  end
 end

--- a/spec/dummy/app/models/vehicle.rb
+++ b/spec/dummy/app/models/vehicle.rb
@@ -1,5 +1,5 @@
 class Vehicle < ApplicationRecord
-  upsert_by :make, :name
+  upsert_keys [:make, :name]
 
   before_save :before_s
   after_save :after_s

--- a/spec/dummy/db/migrate/20160419103547_create_vehicles.rb
+++ b/spec/dummy/db/migrate/20160419103547_create_vehicles.rb
@@ -3,8 +3,11 @@ class CreateVehicles < ActiveRecord::Migration[5.0]
     create_table :vehicles do |t|
       t.integer :wheels_count
       t.string :name
+      t.string :make
 
       t.timestamps
+
+      t.index [:make, :name], unique: true
     end
   end
 end


### PR DESCRIPTION
Carrying an earlier PR by @phoffer. 

---

Fixes #14 

This allows a user to define custom conflict keys on a per model basis. Postgres requires the columns in the clause to match a unique index. I could not find a way to check indices, which would allow for a custom error when setting the keys.

I used `upsert_keys` as the class macro, please let me know if you have a better suggestion. That accepts a single string/symbol, multiple strings/symbols, and an array of strings/symbols. For compound indices, I think the array syntax makes the most sense (matches setting a compound index in migrations), but I wanted to allow both styles. The README example uses an explicit array.

It looks a slight bit more messy than before, but it still works the same for using primary_key (it defaults to that). I have added some specs for this as well.

Please let me know if there's anything else that should be done with this feature. Thanks for the gem!

Lastly, the Travis failures appear to be fixed in #13. I had all specs passing locally when I commented out `require 'rails/test_help'` in spec_helper
