### PR TITLE
Correct README usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or install it yourself as:
 ## Usage
 Just use `ActiveRecord.upsert` or `ActiveRecord#upsert`.
 *ActiveRecordUpsert* respects timestamps.
- 
+
 ```
 class MyRecord < ActiveRecord::Base
 end
@@ -49,12 +49,12 @@ MyRecord.create(name: 'foo', wisdom: 1)
 => #<MyRecord id: 1, name: "foo", created_at: "2016-02-20 14:15:55", updated_at: "2016-02-20 14:15:55", wisdom: 1>
 
 MyRecord.upsert(id: 1, wisdom: 3)
-=> #<MyRecord id: 2, name: "foo", created_at: "2016-02-20 14:15:55", updated_at: "2016-02-20 14:18:15", wisdom: 3>
+=> #<MyRecord id: 1, name: "foo", created_at: "2016-02-20 14:15:55", updated_at: "2016-02-20 14:18:15", wisdom: 3>
 
 r = MyRecord.new(id: 1)
 r.name = 'bar'
 r.upsert
-=> #<MyRecord id: 2, name: "bar", created_at: "2016-02-20 14:17:50", updated_at: "2016-02-20 14:18:49", wisdom: 3>
+=> #<MyRecord id: 1, name: "bar", created_at: "2016-02-20 14:15:55", updated_at: "2016-02-20 14:18:49", wisdom: 3>
 ```
 
 ## Tests


### PR DESCRIPTION
Verified this behaviour in the console. Original README was confusing and incorrectly described the functionality of upsert.