### PR TITLE
Gemspec: arel dep >= 7.0

### DIFF
--- a/active_record_upsert.gemspec
+++ b/active_record_upsert.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.platform = Gem::Platform::RUBY
 
   spec.add_runtime_dependency 'activerecord', '>= 5.0', '< 5.1'
-  spec.add_runtime_dependency "arel", "~>7.0"
+  spec.add_runtime_dependency "arel", ">= 7.0"
   spec.add_runtime_dependency 'pg', '~> 0.18'
 end


### PR DESCRIPTION
This PR tries to make the arel dependency work with 8.0, too.

[Arel changelog](https://github.com/rails/arel/blob/master/History.txt)