### PR TITLE
Allow passing a condition for update

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ r.upsert
 => #<MyRecord id: 1, name: "bar", created_at: "2016-02-20 14:15:55", updated_at: "2016-02-20 14:18:49", wisdom: 3>
 ```
 
+If you need to specify conditions for the update, pass them as Arel queries:
+
+```
+MyRecord.upsert({id: 1, wisdom: 3}, where: [MyRecord.arel_table[:updated_at].lt(1.day.ago)])
+```
+
 Also, it's possible to specify which columns should be used for the conflict clause. **These must comprise a unique index in Postgres.**
 
 ```

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ r.upsert
 => #<MyRecord id: 1, name: "bar", created_at: "2016-02-20 14:15:55", updated_at: "2016-02-20 14:18:49", wisdom: 3>
 ```
 
-If you need to specify conditions for the update, pass them as Arel queries:
+If you need to specify a condition for the update, pass it as an Arel query:
 
 ```ruby
-MyRecord.upsert({id: 1, wisdom: 3}, where: [MyRecord.arel_table[:updated_at].lt(1.day.ago)])
+MyRecord.upsert({id: 1, wisdom: 3}, arel_condition: MyRecord.arel_table[:updated_at].lt(1.day.ago))
 ```
 
 Also, it's possible to specify which columns should be used for the conflict clause. **These must comprise a unique index in Postgres.**

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ If you need to specify a condition for the update, pass it as an Arel query:
 MyRecord.upsert({id: 1, wisdom: 3}, arel_condition: MyRecord.arel_table[:updated_at].lt(1.day.ago))
 ```
 
+The instance `#upsert` can also take keyword arguments to specify a condition, or to limit which attributes to upsert
+(by default, all `changed` attributes will be passed to the upsert):
+
+```ruby
+r = MyRecord.new(id: 1)
+r.name = 'bar'
+r.color = 'blue'
+r.upsert(attributes: [:name], arel_condition: MyRecord.arel_table[:updated_at].lt(1.day.ago))
+# will only update :name, and only if the record is older than 1 day;
+# but if the record does not exist, will insert with both :name and :colors
+```
+
 Also, it's possible to specify which columns should be used for the conflict clause. **These must comprise a unique index in Postgres.**
 
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ r.upsert
 
 If you need to specify conditions for the update, pass them as Arel queries:
 
-```
+```ruby
 MyRecord.upsert({id: 1, wisdom: 3}, where: [MyRecord.arel_table[:updated_at].lt(1.day.ago)])
 ```
 

--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -2,16 +2,16 @@ module ActiveRecordUpsert
   module ActiveRecord
     module PersistenceExtensions
 
-      def upsert(attribute_names=nil)
+      def upsert(attributes: nil, where: [])
         raise ::ActiveRecord::ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
         raise ::ActiveRecord::RecordSavedError, "Can't upsert a record that has already been saved" if persisted?
         values = run_callbacks(:save) {
           run_callbacks(:create) {
-            attribute_names ||= changed
-            attribute_names = attribute_names.map(&:to_s) +
+            attributes ||= changed
+            attributes = attributes.map(&:to_s) +
               timestamp_attributes_for_create_in_model +
               timestamp_attributes_for_update_in_model
-            _upsert_record(attribute_names.uniq)
+            _upsert_record(attributes.uniq, where)
           }
         }
         assign_attributes(values.first.to_h)
@@ -20,19 +20,19 @@ module ActiveRecordUpsert
         false
       end
 
-      def _upsert_record(attribute_names = changed)
+      def _upsert_record(attribute_names = changed, wheres = [])
         attributes_values = arel_attributes_with_values_for_create(attribute_names)
-        values = self.class.unscoped.upsert attributes_values
+        values = self.class.unscoped.upsert(attributes_values, wheres)
         @new_record = false
         values
       end
 
       module ClassMethods
-        def upsert(attributes, &block)
+        def upsert(attributes, where: [], &block)
           if attributes.is_a?(Array)
             attributes.collect { |hash| upsert(hash, &block) }
           else
-            new(attributes, &block).upsert(attributes.keys)
+            new(attributes, &block).upsert(attributes: attributes.keys, where: where)
           end
         end
         def upsert_keys(*keys)

--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -2,7 +2,7 @@ module ActiveRecordUpsert
   module ActiveRecord
     module PersistenceExtensions
 
-      def upsert(attributes: nil, where: [])
+      def upsert(attributes: nil, arel_condition: nil)
         raise ::ActiveRecord::ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
         raise ::ActiveRecord::RecordSavedError, "Can't upsert a record that has already been saved" if persisted?
         values = run_callbacks(:save) {
@@ -11,7 +11,7 @@ module ActiveRecordUpsert
             attributes = attributes.map(&:to_s) +
               timestamp_attributes_for_create_in_model +
               timestamp_attributes_for_update_in_model
-            _upsert_record(attributes.uniq, where)
+            _upsert_record(attributes.uniq, arel_condition)
           }
         }
         assign_attributes(values.first.to_h)
@@ -20,19 +20,19 @@ module ActiveRecordUpsert
         false
       end
 
-      def _upsert_record(attribute_names = changed, wheres = [])
+      def _upsert_record(attribute_names = changed, arel_condition = nil)
         attributes_values = arel_attributes_with_values_for_create(attribute_names)
-        values = self.class.unscoped.upsert(attributes_values, wheres)
+        values = self.class.unscoped.upsert(attributes_values, [arel_condition].compact)
         @new_record = false
         values
       end
 
       module ClassMethods
-        def upsert(attributes, where: [], &block)
+        def upsert(attributes, arel_condition: nil, &block)
           if attributes.is_a?(Array)
             attributes.collect { |hash| upsert(hash, &block) }
           else
-            new(attributes, &block).upsert(attributes: attributes.keys, where: where)
+            new(attributes, &block).upsert(attributes: attributes.keys, arel_condition: arel_condition)
           end
         end
         def upsert_keys(*keys)

--- a/lib/active_record_upsert/active_record/relation.rb
+++ b/lib/active_record_upsert/active_record/relation.rb
@@ -1,7 +1,7 @@
 module ActiveRecordUpsert
   module ActiveRecord
     module RelationExtensions
-      def upsert(values) # :nodoc:
+      def upsert(values, wheres) # :nodoc:
         primary_key_value = nil
 
         if primary_key && Hash === values
@@ -19,6 +19,7 @@ module ActiveRecordUpsert
 
         cm = arel_table.create_on_conflict_do_update
         cm.target = arel_table[column_name]
+        cm.wheres = wheres
         filter = ->(o) { [*column_arr, 'created_at'].include?(o.name) }
 
         cm.set(substitutes.reject { |s| filter.call(s.first) })

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -76,13 +76,13 @@ module ActiveRecord
           it 'does not update the record if the condition does not match' do
             expect {
               MyRecord.upsert(attributes, where: [MyRecord.arel_table[:wisdom].gt(3)])
-            }.to_not change { existing.reload.wisdom }
+            }.to_not change { existing.reload.name }
           end
 
           it 'updates the record if the condition matches' do
             expect {
               MyRecord.upsert(attributes, where: [MyRecord.arel_table[:wisdom].lt(3)])
-            }.to change { existing.reload.wisdom }.to(nil)
+            }.to change { existing.reload.name }.to('othername')
           end
         end
       end

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -75,13 +75,13 @@ module ActiveRecord
         context 'with conditions' do
           it 'does not update the record if the condition does not match' do
             expect {
-              MyRecord.upsert(attributes, where: [MyRecord.arel_table[:wisdom].gt(3)])
+              MyRecord.upsert(attributes, arel_condition: MyRecord.arel_table[:wisdom].gt(3))
             }.to_not change { existing.reload.name }
           end
 
           it 'updates the record if the condition matches' do
             expect {
-              MyRecord.upsert(attributes, where: [MyRecord.arel_table[:wisdom].lt(3)])
+              MyRecord.upsert(attributes, arel_condition: MyRecord.arel_table[:wisdom].lt(3))
             }.to change { existing.reload.name }.to('othername')
           end
         end


### PR DESCRIPTION
Allows passing in an update condition, like

```
MyRecord.upsert({id: 1, wisdom: 3}, where: [MyRecord.arel_table[:updated_at].lt(1.day.ago)])
```

This is useful for example to avoid updating a newer record.