### PR TITLE
Create LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Jesper Josefsson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/active_record_upsert.gemspec
+++ b/active_record_upsert.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Jesper Josefsson", "Olle Jonsson"]
   spec.email         = ["jesper.josefsson@gmail.com", "olle.jonsson@gmail.com"]
   spec.homepage      = "https://github.com/jesjos/active_record_upsert/"
+  spec.license       = 'MIT'
 
   spec.summary       = %q{Real PostgreSQL 9.5+ upserts using ON CONFLICT for ActiveRecord}
 


### PR DESCRIPTION
This PR was created using the instructions at https://help.github.com/articles/adding-a-license-to-a-repository/

It adds a LICENSE file with the MIT license, plus a metadata note in the gemspec.

Fixes #35 