### PR TITLE
Fix updating updated_at and created_at during upsert for ActiveRecord 5.0

### DIFF
--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -9,10 +9,10 @@ module ActiveRecordUpsert
         values = run_callbacks(:save) {
           run_callbacks(:create) {
             attributes ||= changed
-            attributes = attributes.map(&:to_s) +
+            attributes = attributes +
               timestamp_attributes_for_create_in_model +
               timestamp_attributes_for_update_in_model
-            _upsert_record(attributes.uniq, arel_condition)
+            _upsert_record(attributes.map(&:to_s).uniq, arel_condition)
           }
         }
         assign_attributes(values.first.to_h)


### PR DESCRIPTION
Fixes the issue where the timestamps were not updated during the upsert when using ActiveRecord 5.0

ActiveRecord 5.1.x: `ActiveRecord::Timestamp`:
```ruby
def timestamp_attributes_for_update
  [:updated_at, :updated_on]
end
```
ActiveRecord 5.0.x: `ActiveRecord::Timestamp`:

```ruby
def timestamp_attributes_for_update
  ["updated_at", "updated_on"]
end
```