### PR TITLE
Insert records with all values set

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ r.upsert(attributes: [:name], arel_condition: MyRecord.arel_table[:updated_at].l
 # but if the record does not exist, will insert with both :name and :colors
 ```
 
+If you want to create a record with the specific attributes, but update only a limited set of attributes,
+similar to how `ActiveRecord::Base.create_with` works, you can do the following:
+
+```ruby
+existing_record = MyRecord.create(id: 1, name: 'lemon', color: 'green')
+r = MyRecord.new(id: 1, name: 'banana', color: 'yellow')
+r.upsert(attributes: [:color])
+# => #<MyRecord id: 1, name: "lemon", color: "yellow", ...>
+
+r = MyRecord.new(id: 2, name: 'banana', color: 'yellow')
+r.upsert(attributes: [:color])
+
+# => #<MyRecord id: 2, name: "banana", color: "yellow", ...>
+
+# This is similar to:
+
+MyRecord.create_with(name: 'banana').find_or_initialize_by(id: 2).update(color: 'yellow')
+
+```
+
+
 Upsert will perform validation on the object, and return false if it is not valid. To skip validation, pass `validate: false`:
 ```ruby
 MyRecord.upsert({id: 1, wisdom: 3}, validate: false)

--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -25,9 +25,10 @@ module ActiveRecordUpsert
         false
       end
 
-      def _upsert_record(attribute_names = changed, arel_condition = nil)
-        attributes_values = arel_attributes_with_values_for_create(attribute_names)
-        values = self.class.unscoped.upsert(attributes_values, [arel_condition].compact)
+
+      def _upsert_record(upsert_attribute_names = changed, arel_condition = nil)
+        existing_attributes = arel_attributes_with_values_for_create(self.attributes.keys)
+        values = self.class.unscoped.upsert(existing_attributes, upsert_attribute_names, [arel_condition].compact)
         @new_record = false
         values
       end

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -17,6 +17,12 @@ module ActiveRecord
           expect(record.created_at).not_to be_nil
           expect(record.updated_at).not_to be_nil
         end
+
+        it 'updates only given attributes' do
+          record = MyRecord.new(id: 25, name: 'Some name', wisdom: 3)
+          record.upsert(attributes: [:id, :name])
+          expect(record.reload.wisdom).to eq(3)
+        end
       end
 
       context 'when the record already exists' do

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -18,7 +18,7 @@ module ActiveRecord
           expect(record.updated_at).not_to be_nil
         end
 
-        it 'updates only given attributes' do
+        it 'creates record with all the attributes it is initialized with' do
           record = MyRecord.new(id: 25, name: 'Some name', wisdom: 3)
           record.upsert(attributes: [:id, :name])
           expect(record.reload.wisdom).to eq(3)


### PR DESCRIPTION
Allows you to create record with all the values you need, but upsert only needed attributes:
```ruby
record = SomeRecord.new(id: 25, attr1: "foo", attr2: "bar")
record.upsert(attributes: [:attr1])
```
In this example, if the record does not exist, it will be created with `id`, `attr1`, `attr2` set.
But if it exists (and triggers `ON CONFLICT` handler), it will only update `attr1`.