### PR TITLE
Only assign attributes that the model knows about

### DIFF
--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -15,7 +15,7 @@ module ActiveRecordUpsert
             _upsert_record(attributes.map(&:to_s).uniq, arel_condition)
           }
         }
-        assign_attributes(values.first.to_h)
+        assign_attributes(values.first.to_h.slice(*self.attributes.keys))
         self
       end
 


### PR DESCRIPTION
When a migration adds a column to a table, the upsert will start returning the new attribute, and `assign_attributes` will fail because Rails doesn't know about it yet (until the app is restarted).

This checks that only known attributes are being assigned. 
Unfortunately, I can't see an obvious way to test this :/.