### PR TITLE
gemspec: pg gem '>= 0.18', '< 2.0'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,10 @@ gemspec
 
 group :development, :test do
   gem 'bundler', '>= 1.13'
-  gem 'rake', '>= 10.0'
-  gem 'rspec', '>= 3.0', '< 4'
-  gem 'pry', '> 0'
   gem 'database_cleaner', '~> 1.6'
+  gem 'pg', '~> 0.18'
+  gem 'pry', '> 0'
+  gem 'rake', '>= 10.0'
   gem 'rails', '>= 5.0', '< 5.2'
+  gem 'rspec', '>= 3.0', '< 4'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in active_record_upsert.gemspec
 gemspec
 
 group :development, :test do

--- a/Gemfile.docker
+++ b/Gemfile.docker
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in active_record_upsert.gemspec
 gemspec

--- a/active_record_upsert.gemspec
+++ b/active_record_upsert.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activerecord', '>= 5.0', '< 5.2'
   spec.add_runtime_dependency 'arel', '> 7.0', '< 9.0'
-  spec.add_runtime_dependency 'pg', '~> 0.18'
+  spec.add_runtime_dependency 'pg', '>= 0.18', '< 2.0'
 end


### PR DESCRIPTION
This PR updates the `pg` gem's version constraints in the gemspec.

  - trying to harmonize with upcoming Rails - see this commit https://github.com/rails/rails/commit/f820dc2dea3775f6c05c5ca77631ac27a9d3c954#diff-d7ae9a835adce5aead1bf757f121e359
  - our Gemfile's `:test` now explicitly pins to "~> 0.18" since the gemspec's constraints are looser

Fixes #47 