### PR TITLE
Remove rails dependency

### DIFF
--- a/lib/active_record_upsert.rb
+++ b/lib/active_record_upsert.rb
@@ -11,8 +11,10 @@ end
 require 'active_record_upsert/arel'
 require 'active_record_upsert/active_record'
 
-require 'active_record_upsert/compatibility/rails51.rb' if Rails.version >= '5.1.0' && Rails.version < '5.2.0.rc1'
-require 'active_record_upsert/compatibility/rails50.rb' if Rails.version >= '5.0.0' && Rails.version < '5.1.0'
+version = defined?(Rails) ? Rails.version : ActiveRecord.version.to_s
+
+require 'active_record_upsert/compatibility/rails51.rb' if version >= '5.1.0' && version <= '5.2.0.rc2'
+require 'active_record_upsert/compatibility/rails50.rb' if version >= '5.0.0' && version < '5.1.0'
 
 module ActiveRecordUpsert
   # Your code goes here...


### PR DESCRIPTION
We should be able to use this gem only with ActiveRecord and without Rails.
@see #59