### PR TITLE
Fixes implementation for Rails 5.2.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ task :setup_and_run_spec do |rake_task|
 
   require File.expand_path('../spec/dummy/config/environment.rb', __FILE__)
 
-  if Rails.version >= '5.2.0.rc1'
+  if Rails.version >= '5.2.0'
     ActiveRecord::Base.connection.migrations_paths << 'spec/dummy/db/migrate'
   end
 

--- a/lib/active_record_upsert.rb
+++ b/lib/active_record_upsert.rb
@@ -11,7 +11,7 @@ end
 require 'active_record_upsert/arel'
 require 'active_record_upsert/active_record'
 
-require 'active_record_upsert/compatibility/rails51.rb' if Rails.version >= '5.1.0' && Rails.version < '5.2.0.rc1'
+require 'active_record_upsert/compatibility/rails51.rb' if Rails.version >= '5.1.0' && Rails.version < '5.2.0'
 require 'active_record_upsert/compatibility/rails50.rb' if Rails.version >= '5.0.0' && Rails.version < '5.1.0'
 
 module ActiveRecordUpsert

--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -31,7 +31,7 @@ module ActiveRecordUpsert
       end
 
       def _upsert_record(upsert_attribute_names = changed, arel_condition = nil)
-        existing_attributes = arel_attributes_with_values_for_create(self.attributes.keys)
+        existing_attributes = attributes_with_values_for_create(self.attributes.keys)
         values = self.class._upsert_record(existing_attributes, upsert_attribute_names, [arel_condition].compact)
         @new_record = false
         values
@@ -57,7 +57,7 @@ module ActiveRecordUpsert
         def _upsert_record(existing_attributes, upsert_attributes_names, wheres) # :nodoc:
           upsert_keys = self.upsert_keys || [primary_key]
           upsert_attributes_names = upsert_attributes_names - [*upsert_keys, 'created_at']
-          values_for_upsert = existing_attributes.select { |a| upsert_attributes_names.include?(a.name) }
+          values_for_upsert = existing_attributes.select { |(name, _value)| upsert_attributes_names.include?(name) }
 
           insert_manager = arel_table.compile_upsert(
             upsert_keys,


### PR DESCRIPTION
ActiveRecord internals changed a bit again with the release of 5.2.0.
This pull requests adapts to the new changes and fixed the gem for 5.2.0