### PR TITLE
Fix specs about upsert_keys and literal

### DIFF
--- a/lib/active_record_upsert/arel/crud.rb
+++ b/lib/active_record_upsert/arel/crud.rb
@@ -13,7 +13,7 @@ module Arel
   module Crud
     def compile_upsert(upsert_keys, upsert_options, upsert_values, insert_values, wheres)
       # Support non-attribute key (like `md5(my_attribute)``)
-      target = self[upsert_keys.kind_of?(Hash) ? ::Arel::Nodes::SqlLiteral.new(upsert_keys[:literal]) : upsert_keys.join(',')]
+      target = self[upsert_options.key?(:literal) ? ::Arel::Nodes::SqlLiteral.new(upsert_options[:literal]) : upsert_keys.join(',')]
       on_conflict_do_update = OnConflictDoUpdateManager.new
 
       on_conflict_do_update.target = target

--- a/spec/active_record/key_spec.rb
+++ b/spec/active_record/key_spec.rb
@@ -44,7 +44,7 @@ module ActiveRecord
       end
       context 'different ways of setting keys' do
         let(:attrs) { {make: 'Ford', name: 'Focus', long_field: SecureRandom.uuid} }
-        before { Vehicle.create(attrs) }
+        let!(:vehicule) { Vehicle.create(attrs) }
 
         it 'works with multiple symbol args' do
           Vehicle.upsert_keys :make, :name
@@ -71,28 +71,31 @@ module ActiveRecord
           expect(upserted.wheels_count).to eq(1)
         end
         it 'works with a single symbol' do
-          v = Vehicle.create
           Vehicle.upsert_keys :id
-          upserted = Vehicle.new(id: v.id, wheels_count: 1)
-          upserted.upsert
+          upserted = Vehicle.new(id: vehicule.id, name: 'ford', wheels_count: 1)
+          result = upserted.upsert
+
+          expect(result).to be_truthy
           expect(upserted.wheels_count).to eq(1)
-          expect(upserted.id).to eq(v.id)
+          expect(upserted.id).to eq(vehicule.id)
         end
         it 'works with a single string' do
-          v = Vehicle.create
           Vehicle.upsert_keys 'id'
-          upserted = Vehicle.new(id: v.id, wheels_count: 1)
-          upserted.upsert
+          upserted = Vehicle.new(id: vehicule.id, name: 'ford', wheels_count: 1)
+          result = upserted.upsert
+
+          expect(result).to be_truthy
           expect(upserted.wheels_count).to eq(1)
-          expect(upserted.id).to eq(v.id)
+          expect(upserted.id).to eq(vehicule.id)
         end
         it 'works with a literal' do
-          v = Vehicle.create
           Vehicle.upsert_keys literal: 'md5(long_field)'
-          upserted = Vehicle.new(id: v.id, long_field: attrs[:long_field])
-          upserted.upsert
+          upserted = Vehicle.new(id: vehicule.id, name: 'ford', long_field: attrs[:long_field])
+          result = upserted.upsert
+
+          expect(result).to be_truthy
           expect(upserted.long_field).to eq(attrs[:long_field])
-          expect(upserted.id).to eq(v.id)
+          expect(upserted.id).to eq(vehicule.id)
         end
       end
 


### PR DESCRIPTION
### A word about the key specs.
In the key specs, an instance was created like : `upserted  = Vehicle.new(id: v.id, wheels_count: 1)`.
But this one doesn't pass the [validation](https://github.com/jesjos/active_record_upsert/blob/488d69aed3335ff65b7394bf24d5933fd2553608/spec/dummy/app/models/vehicle.rb#L10) because the field `name` is empty.
The `upsert` returns false because of the error on the validation.
So yes the assertion `expect(upserted.id).to eq(vehicule.id)` is always true, but nothing happens in the DB: the spec doesn't test anything.

### About the literal key.
I miss the thing (in #70) that due to [`extract_options!`](https://github.com/jesjos/active_record_upsert/blob/master/lib/active_record_upsert/active_record/persistence.rb#L75), the `literal` key is removed from `upsert_keys` and stored in the `upsert_options` attribute (like the `where` attribute).
So we don't have to check to class of `upsert_key`, but just check if the `upsert_options` constains the `literal` key.
I trust the specs, but nothing happend in DB.