### PR TITLE
Adds #upsert_operation to figure out what happened

### DIFF
--- a/lib/active_record_upsert/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/lib/active_record_upsert/active_record/connection_adapters/postgresql/database_statements.rb
@@ -9,7 +9,7 @@ module ActiveRecordUpsert
           end
 
           def exec_upsert(sql, name, binds)
-            exec_query("#{sql} RETURNING *", name, binds)
+            exec_query("#{sql} RETURNING *, (xmax::text::int = 0) AS _upsert_created_record", name, binds)
           end
         end
       end

--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -32,6 +32,12 @@ module ActiveRecordUpsert
         values
       end
 
+      def upsert_operation
+        created_record = self['_upsert_created_record']
+        return if created_record.nil?
+        created_record ? :create : :update
+      end
+
       module ClassMethods
         def upsert!(attributes, arel_condition: nil, validate: true, &block)
           if attributes.is_a?(Array)

--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -15,12 +15,8 @@ module ActiveRecordUpsert
           }
         }
 
-        # When a migration adds a column to a table, the upsert will start
-        # returning the new attribute, and assign_attributes will fail,
-        # because Rails doesn't know about it yet (until the app is restarted).
-        #
-        # This checks that only known attributes are being assigned.
-        assign_attributes(values.first.to_h.slice(*self.attributes.keys))
+        @attributes = self.class.attributes_builder.build_from_database(values.first.to_h)
+
         self
       end
 

--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -5,7 +5,7 @@ module ActiveRecordUpsert
         raise ::ActiveRecord::ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
         raise ::ActiveRecord::RecordSavedError, "Can't upsert a record that has already been saved" if persisted?
         validate == false || perform_validations || raise_validation_error
-        values = run_callbacks(:save) {
+        run_callbacks(:save) {
           run_callbacks(:create) {
             attributes ||= changed
             attributes = attributes +
@@ -14,8 +14,6 @@ module ActiveRecordUpsert
             _upsert_record(attributes.map(&:to_s).uniq, arel_condition)
           }
         }
-
-        @attributes = self.class.attributes_builder.build_from_database(values.first.to_h)
 
         self
       end
@@ -29,6 +27,7 @@ module ActiveRecordUpsert
       def _upsert_record(upsert_attribute_names = changed, arel_condition = nil)
         existing_attributes = attributes_with_values_for_create(self.attributes.keys)
         values = self.class._upsert_record(existing_attributes, upsert_attribute_names, [arel_condition].compact)
+        @attributes = self.class.attributes_builder.build_from_database(values.first.to_h)
         @new_record = false
         values
       end

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -144,6 +144,14 @@ module ActiveRecord
           expect { MyRecord.upsert(id: record.id, wisdom: 2) }.to raise_error(ActiveRecord::RecordNotUnique)
         end
       end
+
+      context 'when updating attributes from the database' do
+        it 'does not call setter methods' do
+          record = MyRecord.new(name: 'somename', wisdom: 1)
+          expect(record).to_not receive(:name=).with('somename')
+          record.upsert
+        end
+      end
     end
 
     describe '.upsert!' do

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -113,6 +113,33 @@ module ActiveRecord
       end
     end
 
+    describe '#upsert_operation' do
+      let(:attributes) { { id: 1 } }
+
+      context 'when no upsert has been tried' do
+        it 'returns nil' do
+          record = MyRecord.new(attributes)
+          expect(record.upsert_operation).to_not be
+        end
+      end
+
+      context 'when the record does not exist' do
+        it 'returns create' do
+          record = MyRecord.upsert(attributes)
+          expect(record.upsert_operation).to eq(:create)
+        end
+      end
+
+      context 'when the record already exists' do
+        before { MyRecord.create(attributes) }
+
+        it 'returns update' do
+          record = MyRecord.upsert(attributes)
+          expect(record.upsert_operation).to eq(:update)
+        end
+      end
+    end
+
     describe '.upsert' do
       context 'when the record already exists' do
         let(:key) { 1 }

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -11,6 +11,16 @@ module ActiveRecord
         record.upsert
       end
 
+      it 'updates the attribute before calling after callbacks' do
+        MyRecord.create(id: 'some_id', name: 'Some name')
+
+        allow(record).to receive(:after_s) { expect(record.name).to eq('Some name') }
+        allow(record).to receive(:after_c) { expect(record.name).to eq('Some name') }
+        allow(record).to receive(:after_com) { expect(record.name).to eq('Some name') }
+
+        record.upsert
+      end
+
       context 'when the record does not exist' do
         it 'sets timestamps' do
           record.upsert


### PR DESCRIPTION
This pull request adds a new #upsert_operation method that allows to determine what happened in the last upsert call.

As this is mostly useful in callbacks, this pull-request also fixes a problem where attributes loaded from the database wouldn't be update until after the callbacks were called.

Additionally, it changes the way the attributes from the database are set on the model. It now uses a [similar way as ActiveRecord itself](https://github.com/rails/rails/blob/375a4143cf5caeb6159b338be824903edfd62836/activerecord/lib/active_record/persistence.rb#L68-L72).