### PR TITLE
Avoid integer overflow on transaction ids that do not fit in int32

### DIFF
--- a/lib/active_record_upsert/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/lib/active_record_upsert/active_record/connection_adapters/postgresql/database_statements.rb
@@ -9,7 +9,7 @@ module ActiveRecordUpsert
           end
 
           def exec_upsert(sql, name, binds)
-            exec_query("#{sql} RETURNING *, (xmax::text::int = 0) AS _upsert_created_record", name, binds)
+            exec_query("#{sql} RETURNING *, (xmax = 0) AS _upsert_created_record", name, binds)
           end
         end
       end


### PR DESCRIPTION
Par ex, `ERROR:  value "3462765303" is out of range for type integer`

https://www.postgresql.org/docs/9.5/static/ddl-system-columns.html

cc @benedikt what was the motivation to introduce type conversions here?