### PR TITLE
README: Link to that amazing Wikipedia article on PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Real upsert for PostgreSQL 9.5+ and Rails 5 / ActiveRecord 5. Uses [ON CONFLICT 
 
 ## Prerequisites
 
-- PostgreSQL 9.5+
+- PostgreSQL 9.5+ (that's when UPSERT support was added; see Wikipedia's [PostgreSQL Release History](https://en.wikipedia.org/wiki/PostgreSQL#Release_history))
 - ActiveRecord ~> 5
 - For MRI: pg
 


### PR DESCRIPTION
This PR adds a link to the Wikipedia article on PostgreSQL versions. The interested user can learn that the support for UPSERT in PG came in January 2016.