### PR TITLE
Add upsert_keys and upsert_options as opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,24 @@ class Account < ApplicationRecord
 end
 ```
 
+Overriding the models' `upsert_keys` when calling `#upsert` or `.upsert`:
+
+```ruby
+  Account.upsert(attrs, opts: { upsert_keys: [:foo, :bar] })
+  # Or, on an instance:
+  account = Account.new(attrs)
+  account.upsert(opts: { upsert_keys: [:foo, :bar] })
+```
+
+Overriding the models' `upsert_options` (partial index) when calling `#upsert` or `.upsert`:
+
+```ruby
+  Account.upsert(attrs, opts: { upsert_options: { where: 'foo IS NOT NULL' } })
+  # Or, on an instance:
+  account = Account.new(attrs)
+  account.upsert(opts: { upsert_options: { where: 'foo IS NOT NULLL } })
+```
+
 ## Tests
 
 Make sure to have an upsert_test database:

--- a/spec/active_record/key_spec.rb
+++ b/spec/active_record/key_spec.rb
@@ -49,6 +49,7 @@ module ActiveRecord
           expect(upserted.wheels_count).to eq(1)
         end
       end
+
       context 'different ways of setting keys' do
         let(:attrs) { {make: 'Ford', name: 'Focus', long_field: SecureRandom.uuid} }
         let!(:vehicule) { Vehicle.create(attrs) }

--- a/spec/dummy/db/migrate/20190428142610_add_year_to_vehicles.rb
+++ b/spec/dummy/db/migrate/20190428142610_add_year_to_vehicles.rb
@@ -1,0 +1,7 @@
+class AddYearToVehicles < ActiveRecord::Migration[5.0]
+  def change
+    add_column :vehicles, :year, :integer
+    add_index :vehicles, :year, unique: true
+    add_index :vehicles, [:make], unique: true, where: "year IS NULL", name: 'partial_index_vehicles_on_make_without_year'
+  end
+end

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -125,7 +125,8 @@ CREATE TABLE vehicles (
     make character varying,
     long_field character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    year integer
 );
 
 
@@ -239,6 +240,20 @@ CREATE UNIQUE INDEX index_vehicles_on_md5_long_field ON vehicles USING btree (md
 
 
 --
+-- Name: index_vehicles_on_year; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_vehicles_on_year ON vehicles USING btree (year);
+
+
+--
+-- Name: partial_index_vehicles_on_make_without_year; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX partial_index_vehicles_on_make_without_year ON vehicles USING btree (make) WHERE (year IS NULL);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -247,6 +262,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20160419103547'),
 ('20160419124138'),
-('20160419124140');
+('20160419124140'),
+('20190428142610');
 
 


### PR DESCRIPTION
This allows setting of `upsert_keys` and `upsert_options` directly when
calling `#upsert` or `.upsert`. This will overwrite the default
`upsert_keys` and `upsert_options` set in the model.

Resolves https://github.com/jesjos/active_record_upsert/issues/74