### PR TITLE
Use the model.name in the upsert operation's name

### DIFF
--- a/lib/active_record_upsert/compatibility/rails51.rb
+++ b/lib/active_record_upsert/compatibility/rails51.rb
@@ -43,7 +43,7 @@ module ActiveRecordUpsert
         insert_manager.on_conflict = on_conflict_do_update.to_node
         insert_manager.insert substitutes
 
-        @klass.connection.upsert(insert_manager, "#{self} Upsert", binds + on_conflict_binds)
+        @klass.connection.upsert(insert_manager, "#{@klass.name} Upsert", binds + on_conflict_binds)
       end
 
       ::ActiveRecord::Relation.include(self)

--- a/spec/active_record/notifications_spec.rb
+++ b/spec/active_record/notifications_spec.rb
@@ -1,0 +1,27 @@
+module ActiveRecord
+  RSpec.describe 'Base' do
+
+    describe '#upsert' do
+
+      let(:events) { [] }
+
+      before(:each) do
+        @subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+          events << args
+        end
+      end
+
+      after(:each) do
+        ActiveSupport::Notifications.unsubscribe(@subscriber)
+      end
+
+      it 'emits an ActiveSupport notification with an appropriate name' do
+        MyRecord.upsert(wisdom: 2)
+
+        payload = events[-1][-1]
+        expect(payload[:name]).to eq('MyRecord Upsert')
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
When using ActiveRecord 5.0 or 5.1, while subscribing to ActiveSupport::Notifications and using the active_record_upsert gem, events are sent to the subscriber with a payload name like `"#<MyRecord::ActiveRecord_Relation:0x00007ff2bd753958> Upsert"`.  With ActiveRecord 5.2, events are sent to the subscriber with a payload name like `"MyRecord Upsert"`.  

This PR changes the name passed to `connection.upsert` to use the model's name, rather than the `to_s` of the ActiveRecord relation.  