### PR TITLE
Support explicitly naming constraints

### DIFF
--- a/lib/active_record_upsert/arel/crud.rb
+++ b/lib/active_record_upsert/arel/crud.rb
@@ -18,6 +18,7 @@ module Arel
 
       on_conflict_do_update.target = target
       on_conflict_do_update.target_condition = upsert_options[:where]
+      on_conflict_do_update.target_constraint = upsert_options[:constraint]
       on_conflict_do_update.wheres = wheres
       on_conflict_do_update.set(upsert_values)
 

--- a/lib/active_record_upsert/arel/nodes/on_conflict.rb
+++ b/lib/active_record_upsert/arel/nodes/on_conflict.rb
@@ -1,7 +1,7 @@
 module Arel
   module Nodes
     class OnConflict < Node
-      attr_accessor :target, :where, :action
+      attr_accessor :target, :where, :constraint, :action
 
       def initialize
         super

--- a/lib/active_record_upsert/arel/on_conflict_do_update_manager.rb
+++ b/lib/active_record_upsert/arel/on_conflict_do_update_manager.rb
@@ -11,6 +11,10 @@ module Arel
     def target_condition= where
       @ast.where = where
     end
+    
+    def target_constraint= constraint
+      @ast.constraint = constraint
+    end
 
     def target= column
       @ast.target = column

--- a/lib/active_record_upsert/arel/visitors/to_sql.rb
+++ b/lib/active_record_upsert/arel/visitors/to_sql.rb
@@ -13,7 +13,11 @@ module ActiveRecordUpsert
 
         def visit_Arel_Nodes_OnConflict o, collector
           collector << "ON CONFLICT "
-          collector << " (#{quote_column_name o.target.name}) ".gsub(',', '","')
+          collector << if o.constraint.nil? 
+            " (#{quote_column_name o.target.name}) ".gsub(',', '","')
+          else
+            " ON CONSTRAINT #{o.constraint}"
+          end
           collector << " WHERE #{o.where}" if o.where
           maybe_visit o.action, collector
         end

--- a/spec/active_record/constraints_spec.rb
+++ b/spec/active_record/constraints_spec.rb
@@ -1,0 +1,51 @@
+module ActiveRecord
+  RSpec.describe 'Constraint-based conflict keys' do
+    describe '#upsert' do
+      let(:record) { ConstraintExample.new(name: 'John', age: 14, color: 'hot pink') }
+
+      context 'when the record does not exist' do
+        it 'sets timestamps' do
+          record.upsert
+          expect(record.created_at).not_to be_nil
+          expect(record.updated_at).not_to be_nil
+        end
+
+        it 'sets id' do
+          record.color = 'blue'
+          expect(record.id).to be_nil
+          record.upsert(attributes: [:color])
+          expect(record.id).not_to be_nil
+        end
+      end
+
+      context 'when the record already exists' do
+        let(:attrs) { {name: 'John', age: '14', color: 'blue'} }
+        before { ConstraintExample.create(attrs) }
+
+        it 'sets the updated_at timestamp' do
+          first_updated_at = ConstraintExample.find_by(attrs).updated_at
+          upserted = ConstraintExample.new(attrs)
+          upserted.upsert
+          expect(upserted.updated_at).to be > first_updated_at
+        end
+
+        it 'does not reset the created_at timestamp' do
+          first_created_at = ConstraintExample.find_by(attrs).created_at
+          upserted = ConstraintExample.new(attrs)
+          upserted.upsert
+          expect(upserted.created_at).to eq(first_created_at)
+        end
+
+      end
+
+      context 'when the record is not new' do
+        let(:attrs) { {name: 'John', age: '14'} }
+        it 'raises an error' do
+          record = ConstraintExample.create(attrs)
+          record.save
+          expect { record.upsert }.to raise_error(RecordSavedError)
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/models/constraint_example.rb
+++ b/spec/dummy/app/models/constraint_example.rb
@@ -1,0 +1,3 @@
+class ConstraintExample < ActiveRecord::Base
+  upsert_keys constraint: 'my_unique_constraint'
+end

--- a/spec/dummy/db/migrate/20191212121212_create_constraint_examples.rb
+++ b/spec/dummy/db/migrate/20191212121212_create_constraint_examples.rb
@@ -1,0 +1,18 @@
+class CreateConstraintExamples < ActiveRecord::Migration[5.0]
+  def up
+    create_table :constraint_examples do |t|
+      t.string :name
+      t.integer :age
+      t.string :color
+      t.timestamps
+    end
+    
+    execute <<~SQL
+      ALTER TABLE constraint_examples ADD CONSTRAINT my_unique_constraint UNIQUE (name, age);
+    SQL
+  end
+  
+  def down
+    drop_table :constraint_examples
+  end
+end

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -3,35 +3,21 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
-SET search_path = public, pg_catalog;
-
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: accounts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE accounts (
+CREATE TABLE public.accounts (
     id integer NOT NULL,
     name character varying,
     active boolean,
@@ -44,7 +30,7 @@ CREATE TABLE accounts (
 -- Name: accounts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE accounts_id_seq
+CREATE SEQUENCE public.accounts_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -57,14 +43,14 @@ CREATE SEQUENCE accounts_id_seq
 -- Name: accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE accounts_id_seq OWNED BY accounts.id;
+ALTER SEQUENCE public.accounts_id_seq OWNED BY public.accounts.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ar_internal_metadata (
+CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -73,10 +59,44 @@ CREATE TABLE ar_internal_metadata (
 
 
 --
+-- Name: constraint_examples; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.constraint_examples (
+    id integer NOT NULL,
+    name character varying,
+    age integer,
+    color character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: constraint_examples_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.constraint_examples_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: constraint_examples_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.constraint_examples_id_seq OWNED BY public.constraint_examples.id;
+
+
+--
 -- Name: my_records; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE my_records (
+CREATE TABLE public.my_records (
     id integer NOT NULL,
     name character varying,
     wisdom integer,
@@ -89,7 +109,7 @@ CREATE TABLE my_records (
 -- Name: my_records_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE my_records_id_seq
+CREATE SEQUENCE public.my_records_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -102,14 +122,14 @@ CREATE SEQUENCE my_records_id_seq
 -- Name: my_records_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE my_records_id_seq OWNED BY my_records.id;
+ALTER SEQUENCE public.my_records_id_seq OWNED BY public.my_records.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
 
@@ -118,14 +138,15 @@ CREATE TABLE schema_migrations (
 -- Name: vehicles; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE vehicles (
+CREATE TABLE public.vehicles (
     id integer NOT NULL,
     wheels_count integer,
     name character varying,
     make character varying,
     long_field character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    account_id integer
 );
 
 
@@ -133,7 +154,7 @@ CREATE TABLE vehicles (
 -- Name: vehicles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE vehicles_id_seq
+CREATE SEQUENCE public.vehicles_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -146,35 +167,42 @@ CREATE SEQUENCE vehicles_id_seq
 -- Name: vehicles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE vehicles_id_seq OWNED BY vehicles.id;
+ALTER SEQUENCE public.vehicles_id_seq OWNED BY public.vehicles.id;
 
 
 --
 -- Name: accounts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY accounts ALTER COLUMN id SET DEFAULT nextval('accounts_id_seq'::regclass);
+ALTER TABLE ONLY public.accounts ALTER COLUMN id SET DEFAULT nextval('public.accounts_id_seq'::regclass);
+
+
+--
+-- Name: constraint_examples id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.constraint_examples ALTER COLUMN id SET DEFAULT nextval('public.constraint_examples_id_seq'::regclass);
 
 
 --
 -- Name: my_records id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY my_records ALTER COLUMN id SET DEFAULT nextval('my_records_id_seq'::regclass);
+ALTER TABLE ONLY public.my_records ALTER COLUMN id SET DEFAULT nextval('public.my_records_id_seq'::regclass);
 
 
 --
 -- Name: vehicles id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY vehicles ALTER COLUMN id SET DEFAULT nextval('vehicles_id_seq'::regclass);
+ALTER TABLE ONLY public.vehicles ALTER COLUMN id SET DEFAULT nextval('public.vehicles_id_seq'::regclass);
 
 
 --
 -- Name: accounts accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY accounts
+ALTER TABLE ONLY public.accounts
     ADD CONSTRAINT accounts_pkey PRIMARY KEY (id);
 
 
@@ -182,23 +210,39 @@ ALTER TABLE ONLY accounts
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ar_internal_metadata
+ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: constraint_examples constraint_examples_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.constraint_examples
+    ADD CONSTRAINT constraint_examples_pkey PRIMARY KEY (id);
 
 
 --
 -- Name: my_records my_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY my_records
+ALTER TABLE ONLY public.my_records
     ADD CONSTRAINT my_records_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: constraint_examples my_unique_constraint; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.constraint_examples
+    ADD CONSTRAINT my_unique_constraint UNIQUE (name, age);
 
 
 --
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schema_migrations
+ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
@@ -206,7 +250,7 @@ ALTER TABLE ONLY schema_migrations
 -- Name: vehicles vehicles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY vehicles
+ALTER TABLE ONLY public.vehicles
     ADD CONSTRAINT vehicles_pkey PRIMARY KEY (id);
 
 
@@ -214,28 +258,35 @@ ALTER TABLE ONLY vehicles
 -- Name: index_accounts_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_accounts_on_name ON accounts USING btree (name) WHERE (active IS TRUE);
+CREATE UNIQUE INDEX index_accounts_on_name ON public.accounts USING btree (name) WHERE (active IS TRUE);
 
 
 --
 -- Name: index_my_records_on_wisdom; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_my_records_on_wisdom ON my_records USING btree (wisdom);
+CREATE UNIQUE INDEX index_my_records_on_wisdom ON public.my_records USING btree (wisdom);
+
+
+--
+-- Name: index_vehicles_on_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_vehicles_on_account_id ON public.vehicles USING btree (account_id);
 
 
 --
 -- Name: index_vehicles_on_make_and_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_vehicles_on_make_and_name ON vehicles USING btree (make, name);
+CREATE UNIQUE INDEX index_vehicles_on_make_and_name ON public.vehicles USING btree (make, name);
 
 
 --
 -- Name: index_vehicles_on_md5_long_field; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_vehicles_on_md5_long_field ON vehicles USING btree (md5((long_field)::text));
+CREATE UNIQUE INDEX index_vehicles_on_md5_long_field ON public.vehicles USING btree (md5((long_field)::text));
 
 
 --
@@ -247,6 +298,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20160419103547'),
 ('20160419124138'),
-('20160419124140');
+('20160419124140'),
+('20191212121212');
 
 


### PR DESCRIPTION
This PR allows one to pass an explicit Postgres constraint name to `upsert_keys`:

```ruby
class MyClass < ActiveRecord::Base
    upsert_keys constraint: 'my_constraint'
end
```

This generates SQL like 
```SQL
INSERT INTO ... ON CONFLICT ON CONSTRAINT my_constraint DO UPDATE...
```

My only question is the proper quoting of the constraint name. On one hand, I wouldn't expect a dev to SQL-inject themselves. An attacker already having access to ActiveRecord::Base class methods probably obviates the need to be concerned with security. However, I'm raising it now if anyone else thinks it needs to be addressed.

Tests included (which requires migrating your test database). All are passing ✅