### PR TITLE
Upsert allowing keys to be excluded

### DIFF
--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -60,10 +60,14 @@ module ActiveRecordUpsert
           upsert_keys = opts[:upsert_keys] || self.upsert_keys || [primary_key]
           upsert_options = opts[:upsert_options] || self.upsert_options
           upsert_attributes_names = upsert_attributes_names - [*upsert_keys, 'created_at']
-
+          upsert_excluded_keys = upsert_options[:exclude]&.map(&:to_s) || []
+          
           existing_attributes = existing_attributes
+            .except(*upsert_excluded_keys)
             .transform_keys { |name| _prepare_column(name) }
             .reject { |key, _| key.nil? }
+
+          puts "existing_attributes: #{existing_attributes}"
 
           upsert_attributes_names = upsert_attributes_names
             .map { |name| _prepare_column(name) }

--- a/spec/active_record/default_column_spec.rb
+++ b/spec/active_record/default_column_spec.rb
@@ -1,10 +1,12 @@
 module ActiveRecord
-  RSpec.describe 'Alernate conflict keys' do
+  RSpec.describe 'key exclusion' do
     describe '#upsert' do
       let(:record) { DefaultingRecord.new(name: 'Alice') }
       it 'allows the database to set default column values' do
-        record.upsert
-        expect(record.uuid).to_no be_nil
+        record.upsert(opts: {upsert_keys: [:name]})
+        expect(record.uuid).to_not be_nil
+        expect(record.uuid.size).to eq(36)
+        expect(record.uuid).to match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
       end
     end
   end

--- a/spec/active_record/default_column_spec.rb
+++ b/spec/active_record/default_column_spec.rb
@@ -1,0 +1,11 @@
+module ActiveRecord
+  RSpec.describe 'Alernate conflict keys' do
+    describe '#upsert' do
+      let(:record) { DefaultingRecord.new(name: 'Alice') }
+      it 'allows the database to set default column values' do
+        record.upsert
+        expect(record.uuid).to_no be_nil
+      end
+    end
+  end
+end

--- a/spec/dummy/app/models/defaulting_record.rb
+++ b/spec/dummy/app/models/defaulting_record.rb
@@ -1,0 +1,2 @@
+class DefaultingRecord < ApplicationRecord
+end

--- a/spec/dummy/app/models/defaulting_record.rb
+++ b/spec/dummy/app/models/defaulting_record.rb
@@ -1,2 +1,3 @@
 class DefaultingRecord < ApplicationRecord
+  upsert_keys exclude: [:uuid]
 end

--- a/spec/dummy/db/migrate/20200127225354_create_defaulting_records.rb
+++ b/spec/dummy/db/migrate/20200127225354_create_defaulting_records.rb
@@ -1,0 +1,11 @@
+class CreateDefaultingRecords < ActiveRecord::Migration[5.2]
+  def change
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+
+    create_table :defaulting_records do |t|
+      t.uuid :uuid, null: false, default: "gen_random_uuid()"
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -3,35 +3,35 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+-- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
 --
 
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 
 
 --
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+-- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: -
 --
 
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
-
-SET search_path = public, pg_catalog;
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: accounts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE accounts (
+CREATE TABLE public.accounts (
     id integer NOT NULL,
     name character varying,
     active boolean,
@@ -44,7 +44,7 @@ CREATE TABLE accounts (
 -- Name: accounts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE accounts_id_seq
+CREATE SEQUENCE public.accounts_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -57,14 +57,14 @@ CREATE SEQUENCE accounts_id_seq
 -- Name: accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE accounts_id_seq OWNED BY accounts.id;
+ALTER SEQUENCE public.accounts_id_seq OWNED BY public.accounts.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ar_internal_metadata (
+CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -73,10 +73,76 @@ CREATE TABLE ar_internal_metadata (
 
 
 --
+-- Name: constraint_examples; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.constraint_examples (
+    id integer NOT NULL,
+    name character varying,
+    age integer,
+    color character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: constraint_examples_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.constraint_examples_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: constraint_examples_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.constraint_examples_id_seq OWNED BY public.constraint_examples.id;
+
+
+--
+-- Name: defaulting_records; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.defaulting_records (
+    id bigint NOT NULL,
+    uuid uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    name character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: defaulting_records_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.defaulting_records_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: defaulting_records_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.defaulting_records_id_seq OWNED BY public.defaulting_records.id;
+
+
+--
 -- Name: my_records; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE my_records (
+CREATE TABLE public.my_records (
     id integer NOT NULL,
     name character varying,
     wisdom integer,
@@ -89,7 +155,7 @@ CREATE TABLE my_records (
 -- Name: my_records_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE my_records_id_seq
+CREATE SEQUENCE public.my_records_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -102,14 +168,14 @@ CREATE SEQUENCE my_records_id_seq
 -- Name: my_records_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE my_records_id_seq OWNED BY my_records.id;
+ALTER SEQUENCE public.my_records_id_seq OWNED BY public.my_records.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
 
@@ -118,14 +184,16 @@ CREATE TABLE schema_migrations (
 -- Name: vehicles; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE vehicles (
+CREATE TABLE public.vehicles (
     id integer NOT NULL,
     wheels_count integer,
     name character varying,
     make character varying,
     long_field character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    account_id integer,
+    year integer
 );
 
 
@@ -133,7 +201,7 @@ CREATE TABLE vehicles (
 -- Name: vehicles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE vehicles_id_seq
+CREATE SEQUENCE public.vehicles_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -146,35 +214,49 @@ CREATE SEQUENCE vehicles_id_seq
 -- Name: vehicles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE vehicles_id_seq OWNED BY vehicles.id;
+ALTER SEQUENCE public.vehicles_id_seq OWNED BY public.vehicles.id;
 
 
 --
 -- Name: accounts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY accounts ALTER COLUMN id SET DEFAULT nextval('accounts_id_seq'::regclass);
+ALTER TABLE ONLY public.accounts ALTER COLUMN id SET DEFAULT nextval('public.accounts_id_seq'::regclass);
+
+
+--
+-- Name: constraint_examples id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.constraint_examples ALTER COLUMN id SET DEFAULT nextval('public.constraint_examples_id_seq'::regclass);
+
+
+--
+-- Name: defaulting_records id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.defaulting_records ALTER COLUMN id SET DEFAULT nextval('public.defaulting_records_id_seq'::regclass);
 
 
 --
 -- Name: my_records id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY my_records ALTER COLUMN id SET DEFAULT nextval('my_records_id_seq'::regclass);
+ALTER TABLE ONLY public.my_records ALTER COLUMN id SET DEFAULT nextval('public.my_records_id_seq'::regclass);
 
 
 --
 -- Name: vehicles id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY vehicles ALTER COLUMN id SET DEFAULT nextval('vehicles_id_seq'::regclass);
+ALTER TABLE ONLY public.vehicles ALTER COLUMN id SET DEFAULT nextval('public.vehicles_id_seq'::regclass);
 
 
 --
 -- Name: accounts accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY accounts
+ALTER TABLE ONLY public.accounts
     ADD CONSTRAINT accounts_pkey PRIMARY KEY (id);
 
 
@@ -182,23 +264,47 @@ ALTER TABLE ONLY accounts
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ar_internal_metadata
+ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: constraint_examples constraint_examples_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.constraint_examples
+    ADD CONSTRAINT constraint_examples_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: defaulting_records defaulting_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.defaulting_records
+    ADD CONSTRAINT defaulting_records_pkey PRIMARY KEY (id);
 
 
 --
 -- Name: my_records my_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY my_records
+ALTER TABLE ONLY public.my_records
     ADD CONSTRAINT my_records_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: constraint_examples my_unique_constraint; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.constraint_examples
+    ADD CONSTRAINT my_unique_constraint UNIQUE (name, age);
 
 
 --
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schema_migrations
+ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
@@ -206,7 +312,7 @@ ALTER TABLE ONLY schema_migrations
 -- Name: vehicles vehicles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY vehicles
+ALTER TABLE ONLY public.vehicles
     ADD CONSTRAINT vehicles_pkey PRIMARY KEY (id);
 
 
@@ -214,28 +320,49 @@ ALTER TABLE ONLY vehicles
 -- Name: index_accounts_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_accounts_on_name ON accounts USING btree (name) WHERE (active IS TRUE);
+CREATE UNIQUE INDEX index_accounts_on_name ON public.accounts USING btree (name) WHERE (active IS TRUE);
 
 
 --
 -- Name: index_my_records_on_wisdom; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_my_records_on_wisdom ON my_records USING btree (wisdom);
+CREATE UNIQUE INDEX index_my_records_on_wisdom ON public.my_records USING btree (wisdom);
+
+
+--
+-- Name: index_vehicles_on_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_vehicles_on_account_id ON public.vehicles USING btree (account_id);
 
 
 --
 -- Name: index_vehicles_on_make_and_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_vehicles_on_make_and_name ON vehicles USING btree (make, name);
+CREATE UNIQUE INDEX index_vehicles_on_make_and_name ON public.vehicles USING btree (make, name);
 
 
 --
 -- Name: index_vehicles_on_md5_long_field; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_vehicles_on_md5_long_field ON vehicles USING btree (md5((long_field)::text));
+CREATE UNIQUE INDEX index_vehicles_on_md5_long_field ON public.vehicles USING btree (md5((long_field)::text));
+
+
+--
+-- Name: index_vehicles_on_year; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_vehicles_on_year ON public.vehicles USING btree (year);
+
+
+--
+-- Name: partial_index_vehicles_on_make_without_year; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX partial_index_vehicles_on_make_without_year ON public.vehicles USING btree (make) WHERE (year IS NULL);
 
 
 --
@@ -247,6 +374,9 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20160419103547'),
 ('20160419124138'),
-('20160419124140');
+('20160419124140'),
+('20190428142610'),
+('20191212121212'),
+('20200127225354');
 
 


### PR DESCRIPTION
This PR adds `exclude:` to `upsert_options` to allow one to leave certain attributes alone during an upsert. The use case is when a column is defined as ```NOT NULL DEFAULT "something"``` and an attempt to insert NULL into that column is unwanted.

This includes minimal passing tests.

Ruby 2.3+ is required due to the safe navigation operator being used once. If that's undesirable, an explicit check for nil could be used instead.