### PR TITLE
Fix query cache reset

### DIFF
--- a/lib/active_record_upsert/compatibility/rails60.rb
+++ b/lib/active_record_upsert/compatibility/rails60.rb
@@ -5,5 +5,14 @@ module ActiveRecordUpsert
         with_transaction_returning_status { super }
       end
     end
+
+    module ConnectAdapterExtension
+      def upsert(*args)
+        ::ActiveRecord::Base.clear_query_caches_for_current_thread
+        super
+      end
+
+      ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(self)
+    end
   end
 end


### PR DESCRIPTION
Right now `upsert` for ActiveRecord 6.0 + doesn't reset query cache. This compatibility patch fixes it.

https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L17