### PR TITLE
Add Rails 6.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: ruby
 cache:
   bundler: true
 gemfile:
+- Gemfile.rails-6-1
 - Gemfile.rails-6-0
 - Gemfile.rails-5-2
 - Gemfile.rails-5-1
@@ -21,6 +22,8 @@ addons:
   postgresql: '9.5'
 matrix:
   exclude:
+    - rvm: 2.4.6
+      gemfile: Gemfile.rails-6-1
     - rvm: 2.4.6
       gemfile: Gemfile.rails-6-0
     - rvm: 2.4.6

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -5,7 +5,7 @@ gemspec
 group :development, :test do
   gem 'bundler', '>= 1.13'
   gem 'database_cleaner', '~> 1.6'
-  gem 'pg', '~> 0.18'
+  gem 'pg', '~> 1.1'
   gem 'pry', '> 0'
   gem 'rake', '>= 10.0'
   gem 'rspec', '>= 3.0', '< 4'

--- a/Gemfile.rails-6-1
+++ b/Gemfile.rails-6-1
@@ -1,0 +1,5 @@
+group :development, :test do
+  gem 'rails', '>= 6.1.0-rc1', '< 6.2'
+end
+
+eval_gemfile "#{__dir__}/Gemfile.base"

--- a/active_record_upsert.gemspec
+++ b/active_record_upsert.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.platform = Gem::Platform::RUBY
 
-  spec.add_runtime_dependency 'activerecord', '>= 5.0', '< 6.1'
+  spec.add_runtime_dependency 'activerecord', '>= 5.0', '< 6.2'
   spec.add_runtime_dependency 'pg', '>= 0.18', '< 2.0'
 end

--- a/lib/active_record_upsert.rb
+++ b/lib/active_record_upsert.rb
@@ -13,7 +13,7 @@ require 'active_record_upsert/active_record'
 
 version = defined?(Rails) ? Rails.version : ActiveRecord.version.to_s
 
-require 'active_record_upsert/compatibility/rails60.rb' if version >= '6.0.0' && version < '6.1.0'
+require 'active_record_upsert/compatibility/rails60.rb' if version >= '6.0.0' && version < '6.2.0'
 require 'active_record_upsert/compatibility/rails51.rb' if version >= '5.1.0' && version < '5.2.0'
 require 'active_record_upsert/compatibility/rails50.rb' if version >= '5.0.0' && version < '5.1.0'
 


### PR DESCRIPTION
An attempt to add Rails 6.1 support. I'm not really sure about the changes, just took e8972ce75c46bdeca7c59c7539550ac18bf522f4 as an example and made changes that seemed reasonable. Not sure about version specific compatibility need (using 'active_record_upsert/compatibility/rails60.rb'), but my local tests passed.