### PR TITLE
Drop ruby 24 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ gemfile:
 - Gemfile.rails-5-0
 - Gemfile.rails-master
 rvm:
-- 2.4.6
 - 2.5.5
 - 2.6.3
 before_script:
@@ -21,13 +20,6 @@ before_install: gem install bundler
 addons:
   postgresql: '9.5'
 matrix:
-  exclude:
-    - rvm: 2.4.6
-      gemfile: Gemfile.rails-6-1
-    - rvm: 2.4.6
-      gemfile: Gemfile.rails-6-0
-    - rvm: 2.4.6
-      gemfile: Gemfile.rails-master
   allow_failures:
     - gemfile: Gemfile.rails-master
 deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
-FROM quay.io/travisci/travis-ruby
-RUN apt-add-repository ppa:brightbox/ruby-ng
-RUN apt-get update
-RUN apt-get install ruby2.3 ruby2.3-dev
+FROM ruby:latest
 RUN ruby --version
- 
+
 ENV BUNDLE_GEMFILE=/app/Gemfile.docker
-RUN gem install nokogiri
-RUN gem install bundler
+RUN gem install bundler nokogiri
 COPY Gemfile* *.gemspec /app/
 RUN mkdir -p /app/lib/active_record_upsert
 COPY lib/active_record_upsert/version.rb /app/lib/active_record_upsert/
@@ -14,5 +10,4 @@ WORKDIR /app
 RUN bundle install
 COPY . /app
 CMD bin/run_docker_test.sh
-
 


### PR DESCRIPTION
This PR formally **drops Ruby 2.4 support**, by

- removing the Ruby 2.4 CI build matrix element
- stopping usage of EOL versions in the supporting Dockerfile

See #111 for next steps for our CI.