### PR TITLE
Clear model changes after successful upsert

### DIFF
--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -30,6 +30,7 @@ module ActiveRecordUpsert
         values = self.class._upsert_record(existing_attributes, upsert_attribute_names, [arel_condition].compact, opts)
         @attributes = self.class.attributes_builder.build_from_database(values.first.to_h)
         @new_record = false
+        changes_applied
         values
       end
 

--- a/lib/active_record_upsert/compatibility/rails51.rb
+++ b/lib/active_record_upsert/compatibility/rails51.rb
@@ -7,6 +7,7 @@ module ActiveRecordUpsert
         values = self.class.unscoped.upsert(existing_attributes, upsert_attribute_names, [arel_condition].compact, opts)
         @new_record = false
         @attributes = self.class.attributes_builder.build_from_database(values.first.to_h)
+        changes_applied
         values
       end
 

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -33,6 +33,12 @@ module ActiveRecord
           record.upsert(attributes: [:id, :name])
           expect(record.reload.wisdom).to eq(3)
         end
+
+        it 'clears any changes state on the instance' do
+          record.upsert
+          expect(record.changes).to be_empty
+          expect(record.changed?).to be false
+        end
       end
 
       context 'when the record already exists' do
@@ -57,6 +63,13 @@ module ActiveRecord
           upserted = MyRecord.new(id: key)
           upserted.upsert
           expect(upserted.name).to eq('somename')
+        end
+
+        it 'clears any changes' do
+          upserted = MyRecord.new(id: key, name: 'other')
+          upserted.upsert
+          expect(upserted.changes).to be_empty
+          expect(upserted.changed?).to be false
         end
 
         context 'when specifying attributes' do


### PR DESCRIPTION
This prevents other users of the model from thinking it needs to be persisted, and issuing a second SQL query to try and update the database.

Closes https://github.com/jesjos/active_record_upsert/issues/113