### PR TITLE
Run tests using Ruby 2.6, 2.7 and 3.0, clarify EOL policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.5, 2.6, 2.7]
+        ruby-version: [2.6, 2.7, "3.0"]
         gemfile: [Gemfile.rails-6-1, Gemfile.rails-5-2, Gemfile.rails-5-1, Gemfile.rails-5-0]
         experimental: [false]
         include:
-          - ruby-version: 2.7
+          - ruby-version: "3.0"
             gemfile: Gemfile.rails-master
             experimental: true
-          - ruby-version: 2.7
+          - ruby-version: "3.0"
             gemfile: Gemfile.rails-7-0
             experimental: true
+        exclude:
+          - ruby-version: "3.0" # https://github.com/rails/rails/issues/40938
+            gemfile: Gemfile.rails-5-2
+          - ruby-version: "3.0" # https://github.com/rails/rails/issues/40938
+            gemfile: Gemfile.rails-5-1
+          - ruby-version: "3.0" # https://github.com/rails/rails/issues/40938
+            gemfile: Gemfile.rails-5-0
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,14 +16,22 @@ Real upsert for PostgreSQL 9.5+ and Rails 5+ / ActiveRecord 5+. Uses [ON CONFLIC
 
 - PostgreSQL 9.5+ (that's when UPSERT support was added; see Wikipedia's [PostgreSQL Release History](https://en.wikipedia.org/wiki/PostgreSQL#Release_history))
 - ActiveRecord >= 5
-- For MRI: pg
-
-- For JRuby: No support
+- Ruby MRI, with the `pg` gem
+- _JRuby is currently not supported_
 
 ### NB: Releases to avoid
 
 Due to a broken build matrix, v0.9.2 and v0.9.3 are incompatible with Rails
 < 5.2.1. [v0.9.4](https://github.com/jesjos/active_record_upsert/releases/tag/v0.9.4) fixed this issue.
+
+### Supported Ruby versions
+
+This library may be compatible with older versions of Ruby, however we only run automated
+tests using the
+[officially supported Ruby versions](https://www.ruby-lang.org/en/downloads/branches/).
+
+Please note that Ruby 3.1 is not currently tested because it is incompatible with Rails
+`7.0.0`, `6.1.4.4`, `6.0.4.4` and `5.2.6` ([issue](https://github.com/rails/rails/issues/43998)).
 
 ## Installation
 
@@ -135,7 +143,7 @@ When a table is defined with a database default for a field, this gotcha can occ
     │ id      │ integer │ ...
     │ prio    │ integer │ 999
 
-And `hardwares` has a record with a non-default value for `prio`. Say, the record with `id` 1 has a `prio` of `998`. 
+And `hardwares` has a record with a non-default value for `prio`. Say, the record with `id` 1 has a `prio` of `998`.
 
 In this situation, upserting like:
 

--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -18,8 +18,8 @@ module ActiveRecordUpsert
         self
       end
 
-      def upsert(*args)
-        upsert!(*args)
+      def upsert(**kwargs)
+        upsert!(**kwargs)
       rescue ::ActiveRecord::RecordInvalid
         false
       end
@@ -51,8 +51,8 @@ module ActiveRecordUpsert
           end
         end
 
-        def upsert(*args)
-          upsert!(*args)
+        def upsert(attributes, **kwargs, &block)
+          upsert!(attributes, **kwargs, &block)
         rescue ::ActiveRecord::RecordInvalid
           false
         end

--- a/lib/active_record_upsert/compatibility/rails60.rb
+++ b/lib/active_record_upsert/compatibility/rails60.rb
@@ -1,13 +1,13 @@
 module ActiveRecordUpsert
   module ActiveRecord
     module TransactionsExtensions
-      def upsert(*args)
+      def upsert(*args, **kwargs)
         with_transaction_returning_status { super }
       end
     end
 
     module ConnectAdapterExtension
-      def upsert(*args)
+      def upsert(*args, **kwargs)
         ::ActiveRecord::Base.clear_query_caches_for_current_thread
         super
       end

--- a/lib/active_record_upsert/compatibility/rails70.rb
+++ b/lib/active_record_upsert/compatibility/rails70.rb
@@ -42,13 +42,13 @@ module ActiveRecordUpsert
     end
 
     module TransactionsExtensions
-      def upsert(*args)
+      def upsert(*args, **kwargs)
         with_transaction_returning_status { super }
       end
     end
 
     module ConnectAdapterExtension
-      def upsert(*args)
+      def upsert(*args, **kwargs)
         ::ActiveRecord::Base.clear_query_caches_for_current_thread
         super
       end

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -128,13 +128,13 @@ module ActiveRecord
 
         context 'when the record matches the partial index' do
           it 'raises an error' do
-            expect{ Account.upsert!(name: 'somename', active: true) }.not_to change{ Account.count }.from(1)
+            expect{ Account.upsert!({ name: 'somename', active: true }) }.not_to change{ Account.count }.from(1)
           end
         end
 
         context 'when the record does meet the where clause' do
           it 'raises an error' do
-            expect{ Account.upsert!(name: 'somename', active: false) }.to change{ Account.count }.from(1).to(2)
+            expect{ Account.upsert!({ name: 'somename', active: false }) }.to change{ Account.count }.from(1).to(2)
           end
         end
       end
@@ -233,7 +233,7 @@ module ActiveRecord
 
         it 'updates the foreign keys' do
           expect {
-            Vehicle.upsert!(make: existing.make, name: existing.name, account: account)
+            Vehicle.upsert!({ make: existing.make, name: existing.name, account: account })
           }.to change { existing.reload.account_id }.from(nil).to(account.id)
         end
       end
@@ -242,7 +242,7 @@ module ActiveRecord
         it 'raises an error' do
           record = MyRecord.create(name: 'somename', wisdom: 1)
           MyRecord.create(name: 'other', wisdom: 2)
-          expect { MyRecord.upsert(id: record.id, wisdom: 2) }.to raise_error(ActiveRecord::RecordNotUnique)
+          expect { MyRecord.upsert({ id: record.id, wisdom: 2 }) }.to raise_error(ActiveRecord::RecordNotUnique)
         end
       end
 
@@ -257,7 +257,7 @@ module ActiveRecord
 
     describe '.upsert!' do
       it 'raises ActiveRecord::RecordInvalid if the object is invalid' do
-        expect { Vehicle.upsert!(wheels_count: 4) }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { Vehicle.upsert!({ wheels_count: 4 }) }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end

--- a/spec/active_record/notifications_spec.rb
+++ b/spec/active_record/notifications_spec.rb
@@ -16,7 +16,7 @@ module ActiveRecord
       end
 
       it 'emits an ActiveSupport notification with an appropriate name' do
-        MyRecord.upsert(wisdom: 2)
+        MyRecord.upsert({ wisdom: 2 })
 
         payload = events[-1][-1]
         expect(payload[:name]).to eq('MyRecord Upsert')


### PR DESCRIPTION
Note that Rails 6+ does not run on Ruby 2.6, so they must be explicitly excluded from testing - see rails/rails#40938.

I also had to fix some issues with Ruby 3 keyword arguments, see the second commit.

Closes https://github.com/jesjos/active_record_upsert/issues/116