### PR TITLE
fix: Support commit callbacks when calling upsert!

### DIFF
--- a/lib/active_record_upsert/compatibility/rails60.rb
+++ b/lib/active_record_upsert/compatibility/rails60.rb
@@ -4,6 +4,10 @@ module ActiveRecordUpsert
       def upsert(*args, **kwargs)
         with_transaction_returning_status { super }
       end
+
+      def upsert!(*args, **kwargs)
+        with_transaction_returning_status { super }
+      end
     end
 
     module ConnectAdapterExtension

--- a/lib/active_record_upsert/compatibility/rails70.rb
+++ b/lib/active_record_upsert/compatibility/rails70.rb
@@ -45,6 +45,10 @@ module ActiveRecordUpsert
       def upsert(*args, **kwargs)
         with_transaction_returning_status { super }
       end
+
+      def upsert!(*args, **kwargs)
+        with_transaction_returning_status { super }
+      end
     end
 
     module ConnectAdapterExtension

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -2,13 +2,22 @@ module ActiveRecord
   RSpec.describe 'Base' do
     describe '#upsert' do
       let(:record) { MyRecord.new(id: 'some_id') }
-      it 'calls save/create/commit callbacks' do
+      it 'calls save/create/commit callbacks on #upsert' do
         expect(record).to receive(:before_s)
         expect(record).to receive(:after_s)
         expect(record).to receive(:after_c)
         expect(record).to receive(:before_c)
         expect(record).to receive(:after_com)
         record.upsert
+      end
+
+      it 'calls save/create/commit callbacks on #upsert!' do
+        expect(record).to receive(:before_s)
+        expect(record).to receive(:after_s)
+        expect(record).to receive(:after_c)
+        expect(record).to receive(:before_c)
+        expect(record).to receive(:after_com)
+        record.upsert!
       end
 
       it 'updates the attribute before calling after callbacks' do


### PR DESCRIPTION
The test created in the testfile was failing before. I'm not sure if the fix is correct when it comes to the class method if it is on purpose that is happens without the transaction but without changing this there is a failing spec in the notification spec.