### PR TITLE
CI: experimental: true means to continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           bundler-cache: true
 
       - name: Run Tests
+        continue-on-error: ${{ matrix.experimental == true }}
         run: |
           export DATABASE_URL=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/$POSTGRES_DB
           bundle exec rake spec


### PR DESCRIPTION
This now decides that the test Step may fail on Rails main, which is not yet supported.