### PR TITLE
Support Rails 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ jobs:
           - ruby-version: "3.2"
             gemfile: Gemfile.rails-7-1
             experimental: false
-          - ruby-version: "3.2"
+          - ruby-version: "3.3"
+            gemfile: Gemfile.rails-7-2
+            experimental: false
+          - ruby-version: "3.3"
             gemfile: Gemfile.rails-main
             experimental: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-eval_gemfile "#{__dir__}/Gemfile.rails-5-2"
+eval_gemfile "#{__dir__}/Gemfile.rails-7-2"

--- a/Gemfile.rails-7-2
+++ b/Gemfile.rails-7-2
@@ -1,0 +1,5 @@
+group :development, :test do
+  gem 'rails', '~> 7.2.0'
+end
+
+eval_gemfile "#{__dir__}/Gemfile.base"

--- a/active_record_upsert.gemspec
+++ b/active_record_upsert.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.platform = Gem::Platform::RUBY
 
-  spec.add_runtime_dependency 'activerecord', '>= 5.2', '< 7.2'
+  spec.add_runtime_dependency 'activerecord', '>= 5.2', '< 8.0'
   spec.add_runtime_dependency 'pg', '>= 0.18', '< 2.0'
 end

--- a/lib/active_record_upsert.rb
+++ b/lib/active_record_upsert.rb
@@ -13,8 +13,11 @@ require 'active_record_upsert/active_record'
 
 version = defined?(Rails) ? Rails.version : ActiveRecord.version.to_s
 
-require 'active_record_upsert/compatibility/rails70.rb' if version >= '7.0.0' && version < '8.0.0'
-require 'active_record_upsert/compatibility/rails60.rb' if version >= '6.0.0' && version < '6.2.0'
+if version >= '7.0.0'
+  require 'active_record_upsert/compatibility/rails70.rb'
+elsif version >= '6.0.0' && version < '6.2.0'
+  require 'active_record_upsert/compatibility/rails60.rb'
+end
 
 module ActiveRecordUpsert
   # Your code goes here...

--- a/lib/active_record_upsert.rb
+++ b/lib/active_record_upsert.rb
@@ -13,7 +13,7 @@ require 'active_record_upsert/active_record'
 
 version = defined?(Rails) ? Rails.version : ActiveRecord.version.to_s
 
-require 'active_record_upsert/compatibility/rails70.rb' if version >= '7.0.0' && version < '7.2.0'
+require 'active_record_upsert/compatibility/rails70.rb' if version >= '7.0.0' && version < '8.0.0'
 require 'active_record_upsert/compatibility/rails60.rb' if version >= '6.0.0' && version < '6.2.0'
 
 module ActiveRecordUpsert


### PR DESCRIPTION
Add support for Rails 7.2 and a CI job for Ruby 3.3.

This MR expands the compatibility module to be included for Rails 7.2.