### PR TITLE
Support Rails 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
             gemfile: Gemfile.rails-7-2
             experimental: false
           - ruby-version: "3.3"
+            gemfile: Gemfile.rails-8-0
+            experimental: false
+          - ruby-version: "3.3"
             gemfile: Gemfile.rails-main
             experimental: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-eval_gemfile "#{__dir__}/Gemfile.rails-7-2"
+eval_gemfile "#{__dir__}/Gemfile.rails-8-0"

--- a/Gemfile.rails-8-0
+++ b/Gemfile.rails-8-0
@@ -1,0 +1,5 @@
+group :development, :test do
+  gem 'rails', '~> 8.0.0'
+end
+
+eval_gemfile "#{__dir__}/Gemfile.base"

--- a/active_record_upsert.gemspec
+++ b/active_record_upsert.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.platform = Gem::Platform::RUBY
 
-  spec.add_runtime_dependency 'activerecord', '>= 5.2', '< 8.0'
+  spec.add_runtime_dependency 'activerecord', '>= 5.2', '< 8.1'
   spec.add_runtime_dependency 'pg', '>= 0.18', '< 2.0'
 end


### PR DESCRIPTION
Add support for Rails 8.0.

The same compatibility module for Rails 7.x works for 8.0 too. You only need to release a new version, bumping the dependency constraint.
