### PR TITLE
CI: use actions/checkout v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             gemfile: Gemfile.rails-5-2
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare database
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+      - name: Ensure working RubyGems
+        run: gem update --system 3.2.3
       - name: Prepare database
         run: |
           psql postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/$POSTGRES_DB < spec/dummy/db/structure.sql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Ensure working RubyGems
-        run: gem update --system 3.2.3
       - name: Prepare database
         run: |
           psql postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/$POSTGRES_DB < spec/dummy/db/structure.sql
@@ -83,6 +81,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+          rubygems: 3.2.3
 
       - name: Run Tests
         run: |

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'logger' # Fix concurrent-ruby removing logger dependency which Rails itself does not have
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'active_record'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require 'logger' # Fix concurrent-ruby removing logger dependency which Rails itself does not have
+require 'logger' # Fix concurrent-ruby removing "logger" dependency which Rails itself does not have
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'active_record'

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -2,4 +2,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require "logger" # Fix concurrent-ruby removing logger dependency which Rails itself does not have
 $LOAD_PATH.unshift File.expand_path('../../../../lib', __FILE__)

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -2,5 +2,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-require "logger" # Fix concurrent-ruby removing logger dependency which Rails itself does not have
+require "logger" # Fix concurrent-ruby removing "logger" dependency which Rails itself does not have
 $LOAD_PATH.unshift File.expand_path('../../../../lib', __FILE__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'logger' # Fix concurrent-ruby removing logger dependency which Rails itself does not have
+require 'logger' # Fix concurrent-ruby removing "logger" dependency which Rails itself does not have
 require 'active_record'
 require 'database_cleaner'
 require 'securerandom'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'logger' # Fix concurrent-ruby removing logger dependency which Rails itself does not have
 require 'active_record'
 require 'database_cleaner'
 require 'securerandom'


### PR DESCRIPTION
This PR keeps a CI action up to date.

EDIT: Wow, that showed us 


> Your RubyGems version (3.0.3.1) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`
rake aborted!

EDIT: Now,

some versions of ActiveSupport are... needy

```
NameError: uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
```