### PR TITLE
chore: Add support for Rails 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    types: [opened, reopened, synchronize]
   push:
     branches:
-      - 'main'
+      - "main"
 
 jobs:
   test:
@@ -56,7 +56,10 @@ jobs:
           - ruby-version: "3.3"
             gemfile: Gemfile.rails-8-0
             experimental: false
-          - ruby-version: "3.3"
+          - ruby-version: "3.4"
+            gemfile: Gemfile.rails-8-1
+            experimental: false
+          - ruby-version: "3.4"
             gemfile: Gemfile.rails-main
             experimental: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-eval_gemfile "#{__dir__}/Gemfile.rails-8-0"
+eval_gemfile "#{__dir__}/Gemfile.rails-8-1"

--- a/Gemfile.rails-8-1
+++ b/Gemfile.rails-8-1
@@ -1,0 +1,5 @@
+group :development, :test do
+gem 'rails', '~> 8.1.0'
+end
+
+eval_gemfile "#{__dir__}/Gemfile.base"

--- a/active_record_upsert.gemspec
+++ b/active_record_upsert.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.platform = Gem::Platform::RUBY
 
-  spec.add_runtime_dependency 'activerecord', '>= 5.2', '< 8.1'
+  spec.add_runtime_dependency 'activerecord', '>= 5.2', '< 8.2'
   spec.add_runtime_dependency 'pg', '>= 0.18', '< 2.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,4 +29,9 @@ RSpec.configure do |config|
       ActiveRecord::Tasks::DatabaseTasks.truncate_all
     end
   end
+
+  if ENV.key?('GITHUB_ACTIONS')
+    config.color = true
+    config.tty = true
+  end
 end


### PR DESCRIPTION
Add Rails 8.1 and Ruby 3.4 to the test matrix and gemspec.

The other two commits are little improvements to optionally run CI before making a PR and to have colored RSpec output there.